### PR TITLE
🔀 북마크 삭제 후 그리드뷰 셀 잘리는 문제 해결

### DIFF
--- a/Projects/Feature/BaseFeature/Demo/Sources/Views/ProductDetailTableHeaderView.swift
+++ b/Projects/Feature/BaseFeature/Demo/Sources/Views/ProductDetailTableHeaderView.swift
@@ -48,7 +48,7 @@ class ProductDetailTableHeaderView: UITableViewHeaderFooterView {
     }
     
     lazy var saveButton: UIButton = UIButton().then {
-        $0.setImage(DesignSystemAsset.Icon.blueBookMark.image, for: .normal)
+        $0.setImage(DesignSystemAsset.Icon.bluebookMark.image, for: .normal)
     }
     
     lazy var emptyView: UIView = UIView().then {

--- a/Projects/Feature/BaseFeature/Sources/Views/PinterestCollectionViewCell.swift
+++ b/Projects/Feature/BaseFeature/Sources/Views/PinterestCollectionViewCell.swift
@@ -38,7 +38,7 @@ public final class PinterestCollectionViewCell: UICollectionViewCell {
     }
     
     public lazy var bookmarkButton = UIButton().then { // 필요할 때 isHidden 시키기
-        $0.setImage(DesignSystemAsset.Icon.blueBookMark.image, for: .normal)
+        $0.setImage(DesignSystemAsset.Icon.bluebookMark.image, for: .normal)
         $0.setImage(DesignSystemAsset.Icon.emptyBookMark.image, for: .selected)
         $0.addTarget(self, action: #selector(touchUpBookmark), for: .touchUpInside)
     }
@@ -80,7 +80,7 @@ extension PinterestCollectionViewCell {
         }
     }
     
-    public func update(model: ProductEntity) {
+    public func update(model: ProductEntity, isBookMark: Bool = false, id: Int = 0) {
         self.imageView.kf.setImage(with: URL(string: model.mainImage), placeholder: DesignSystemAsset.PlaceHolder.largePH.image)
         self.title.text = model.name
         self.id = id // 북마크에서 사용될 값

--- a/Projects/Feature/BaseFeature/Sources/Views/ProductDetailTableHeaderView.swift
+++ b/Projects/Feature/BaseFeature/Sources/Views/ProductDetailTableHeaderView.swift
@@ -165,7 +165,7 @@ extension ProductDetailTableHeaderView {
         designerLabel.setMultipleAttributeText(text1: "디자인  ", text2: model.designer, color1: DesignSystemAsset.Grey.grey300.color, color2: .black, font1: .subtitle3, font2: .body2)
         
         
-        saveButton.setImage(isSaved ? DesignSystemAsset.Icon.blueBookMark.image : DesignSystemAsset.Icon.emptyBookMark.image, for: .normal)
+        saveButton.setImage(isSaved ? DesignSystemAsset.Icon.bluebookMark.image : DesignSystemAsset.Icon.emptyBookMark.image, for: .normal)
         
         collectionView.reloadData()
     }

--- a/Projects/Feature/HomeFeature/Sources/Views/CategoryCollectionViewCell.swift
+++ b/Projects/Feature/HomeFeature/Sources/Views/CategoryCollectionViewCell.swift
@@ -18,7 +18,7 @@ final class CategoryCollectionViewCell: UICollectionViewCell {
     static let identifier = "CategoryCollectionViewCell"
     
     private let image = UIImageView().then {
-        $0.image = DesignSystemAsset.Icon.blueBookMark.image
+        $0.image = DesignSystemAsset.Icon.bluebookMark.image
         $0.contentMode = .scaleAspectFit
     }
     

--- a/Projects/UserInterface/DesignSystem/Sources/Layout/AutoHeightCollectionViewLayout.swift
+++ b/Projects/UserInterface/DesignSystem/Sources/Layout/AutoHeightCollectionViewLayout.swift
@@ -49,6 +49,9 @@ public class AutoHeightCollectionViewLayout: UICollectionViewLayout {
         
         for item in 0..<collectionView.numberOfItems(inSection: 0) { // 전체 item 개수를 돌면서, 캐시에 아이템 정보 저장
             let indexPath = IndexPath(item: item, section: 0)
+            if indexPath.row == 0 {
+                contentHeight = 0
+            }
             
             // 동적 높이 계산
             let photoHeight = delegate?.collectionView(collectionView, heightForPhotoAtIndexPath: indexPath) ?? 200
@@ -63,7 +66,7 @@ public class AutoHeightCollectionViewLayout: UICollectionViewLayout {
                     attributes.frame = insetFrame
                     cache.append(attributes)
             
-            contentHeight = frame.maxY
+            contentHeight = max(frame.maxY, contentHeight)
             
             yOffset[column] += height
             column = column < (numberOfColumns - 1) ? (column + 1) : 0


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- feature/#155

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
<img src="https://github.com/PrintingAlley/PrintingAlley-iOS/assets/70744494/c44eb38e-3133-4642-8d8d-68a26cbcf9f5" width="250">

indexPath 값이 더 높은데 셀 높이는 더 작은 경우, 같은 줄의 이전 indexPath 셀 아래가 잘리는 문제 해결



## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- indexPath 값이 더 높은데 셀 높이는 더 작은 경우, 같은 줄의 이전 indexPath 셀 아래가 잘려서 생기는 문제였음
 ㄴ `contentHeight = max(contentHeight, frame.maxY)` 로 셀이 잘리는 문제를 해결

| 삭제 전 | 삭제 후 |
|:--:|:--:|
| <img width="250" alt="스크린샷 2023-11-13 오전 9 41 23" src="https://github.com/PrintingAlley/PrintingAlley-iOS/assets/70744494/6e8b061c-8ee6-4a55-beae-1973f8aa1164"> | <img width="250" alt="스크린샷 2023-11-13 오전 9 42 18" src="https://github.com/PrintingAlley/PrintingAlley-iOS/assets/70744494/9e19614f-9c2d-4495-9ea2-222f8f071101"> |





- `indexPath.row == 0` 일 경우 contentHeight 을 0으로 초기화시켜줌으로써 필터 변경 시 스크롤뷰 height 초기화시켜줌


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|북마크 삭제|<img src = "https://github.com/PrintingAlley/PrintingAlley-iOS/assets/70744494/ba42ae0a-0646-4467-9ebd-754110876d9a" width ="250">|

## 📟 관련 이슈
- Resolved: #155 
